### PR TITLE
feat: prevent idling by playing silent audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ This node plays sound in the following order of priority.
 1. Notify operator by `voice alarm` once that the system has booted successfully.
 1. Keep informed by `voice alarm` that the system is being in shut down sequence.
 
+Audio playback interruption function due to idling.
+Even when the car is not running, the background music keeps playing quietly to prevent idling.
+
 ## Input and Output
 - input
   - from [autoware.universe](https://github.com/autowarefoundation/autoware.universe)
@@ -64,7 +67,3 @@ This node plays sound in the following order of priority.
 The specific values for these parameters are defined in the ad_sound package.
 
 If you want to use different sound, fork the [ad_sound.default](https://github.com/eve-autonomy/ad_sound.default) repository, create a new repository.
-
-## remarks
-On some devices, after stopping audio playback for a period of time, the audio device automatically goes idle and does not play the beginning of the audio when it returns from idle.  
-The ad_sound_manager silently plays sound files registered in background music to prevent the device from automatically idling audio after transitioning to STATE_CHECK_NODE_ALIVE state.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,14 @@ This node plays sound in the following order of priority.
 1. Notify operator by `voice alarm` once that the system has booted successfully.
 1. Keep informed by `voice alarm` that the system is being in shut down sequence.
 
-Audio playback interruption function due to idling.
-Even when the car is not running, the background music keeps playing quietly to prevent idling.
+### Anti-idling function for audio device
 
+This node provides a function to prevent idling by continuously playing extremely low volume even if there is no audio playback request.  
+
+If the audio device does not play audio for a while, the audio device will automatically go idle.  
+This idle state is cleared when the next audio playback starts, but the problem is that the audio cuts out immediately after it starts.  
+
+By continuing to play background music at a very low volume when the vehicle is not moving (no background music required), other sounds can be played without the initial interruption due to idling.  
 ## Input and Output
 - input
   - from [autoware.universe](https://github.com/autowarefoundation/autoware.universe)

--- a/README.md
+++ b/README.md
@@ -64,3 +64,7 @@ This node plays sound in the following order of priority.
 The specific values for these parameters are defined in the ad_sound package.
 
 If you want to use different sound, fork the [ad_sound.default](https://github.com/eve-autonomy/ad_sound.default) repository, create a new repository.
+
+## remarks
+On some devices, after stopping audio playback for a period of time, the audio device automatically goes idle and does not play the beginning of the audio when it returns from idle.  
+The ad_sound_manager silently plays sound files registered in background music to prevent the device from automatically idling audio after transitioning to STATE_CHECK_NODE_ALIVE state.

--- a/src/ad_sound_manager.cpp
+++ b/src/ad_sound_manager.cpp
@@ -326,7 +326,7 @@ void AdSoundManager::changeSoundState(
     (cur_control_layer_state_ == autoware_state_machine_msgs::msg::StateMachine::MANUAL))
   {
     continuity_state_ = false;
-    pub_bgm_cmd_->publish(initAudioCmd(sdc_msg_.CMD_STOP));
+    playLoopNoBGM(sound_filename_bgm_);
     pub_voice_cmd_->publish(initAudioCmd(sdc_msg_.CMD_STOP));
     pre_sound_filename_ = "";
     return;
@@ -359,7 +359,7 @@ void AdSoundManager::changeSoundState(
       pre_sound_filename_ = "";
       break;
     case autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_CALL_PERMISSION:
-      pub_bgm_cmd_->publish(initAudioCmd(sdc_msg_.CMD_STOP));
+      playLoopNoBGM(sound_filename_bgm_);
       continuity_state_ = false;
       playLoopVoice(sound_filename_call_, false, true);
       break;
@@ -481,7 +481,7 @@ void AdSoundManager::changeSoundState(
     case autoware_state_machine_msgs::msg::StateMachine::STATE_DURING_WAKEUP:
     case autoware_state_machine_msgs::msg::StateMachine::STATE_DURING_CLOSE:
     case autoware_state_machine_msgs::msg::StateMachine::STATE_DURING_RECEIVE_ROUTE:
-      pub_bgm_cmd_->publish(initAudioCmd(sdc_msg_.CMD_STOP));
+      playLoopNoBGM(sound_filename_bgm_);
       continuity_state_ = false;
       pub_voice_cmd_->publish(initAudioCmd(sdc_msg_.CMD_STOP));
       pre_sound_filename_ = "";


### PR DESCRIPTION
# Description
## Current problem
There was a problem that the beginning of the audio was not played in the STATE_WAITING_CALL_PERMISSION state.  
On some devices, after stopping audio playback for a period of time, the audio device automatically goes idle and does not play the beginning of the audio when it returns from idle.  

## Countermeasures
Change the stopped portion of the BGM to silent playback. 
This change prevents audio devices from becoming idle while the system is running. 

## Confirmation details
Execute the following command.
```
$ ros2 topic pub /autoware_state_machine/state autoware_state_machine_msgs/msg/StateMachine '{service_layer_state: 201, control_layer_state: 1}' --qos-durability transient_local --qos-reliability reliable --once
$ ros2 topic pub /autoware_state_machine/state autoware_state_machine_msgs/msg/StateMachine '{service_layer_state: 250, control_layer_state: 1}' --qos-durability transient_local --qos-reliability reliable --once
```
### Before measures:  
call.wav is played in a loop, but the beginning of the audio playback after the second time is cut off.

### After measures:  
Loop playback of call.wav works correctly.

## Review Procedure

 * Make sure the description is valid.
 * Make sure that what is described in the description matches the implementation.