### PR TITLE
fix: turn right/left and emergency stete sound

### DIFF
--- a/src/ad_sound_manager.cpp
+++ b/src/ad_sound_manager.cpp
@@ -37,9 +37,10 @@ AdSoundManager::AdSoundManager(const rclcpp::NodeOptions & options = rclcpp::Nod
   );
 
   // For: /api/vehicle/status
+  // Note: Use SensorDataQoS (BEST_EFFORT + volatile) to match publisher QoS
   sub_adapi_vehicle_status_ = this->create_subscription<autoware_adapi_v1_msgs::msg::VehicleStatus>(
     "/api/vehicle/status",
-    rclcpp::QoS{1}.transient_local(),
+    rclcpp::SensorDataQoS(),
     std::bind(&AdSoundManager::callbackAdapiVehicleStatus, this, std::placeholders::_1)
   );
 
@@ -1026,8 +1027,32 @@ void AdSoundManager::updateAutowareStateFromTopics(void)
     service_layer_state = StateMachine::STATE_UNDEFINED;
   }
 
+  // 詳細デバッグログ：全トピック情報を時系列で出力
   RCLCPP_WARN(this->get_logger(),
-    "[DEBUG] updateAutowareStateFromTopics CALLING changeSoundState: derived_service=%s, derived_control=%s",
+    "\n========== [STATE TRANSITION LOG] ==========\n"
+    "  motion_state: %s (prev: %s)\n"
+    "  route_state: %s\n"
+    "  localization_state: %s\n"
+    "  turn_indicators: %d\n"
+    "  has_started_driving: %s\n"
+    "  is_playing_restart_sound: %s\n"
+    "  is_playing_engage_sound: %s\n"
+    "  engage_sound_completed: %s\n"
+    "  voice_flg: %s, lock_flg: %s\n"
+    "  --> derived_service: %s\n"
+    "  --> derived_control: %s\n"
+    "=============================================",
+    motionStateToString(motion_state_.state).c_str(),
+    motionStateToString(prev_motion_state_.state).c_str(),
+    routeStateToString(route_state_.state).c_str(),
+    localizationStateToString(localization_state_.state).c_str(),
+    adapi_vehicle_status_.turn_indicators.status,
+    has_started_driving_ ? "true" : "false",
+    is_playing_restart_sound_ ? "true" : "false",
+    is_playing_engage_sound_ ? "true" : "false",
+    engage_sound_completed_ ? "true" : "false",
+    go_interface_vehicle_status_.voice_flg ? "true" : "false",
+    go_interface_vehicle_status_.lock_flg ? "true" : "false",
     serviceLayerStateToString(service_layer_state).c_str(),
     controlLayerStateToString(control_layer_state).c_str());
 

--- a/src/ad_sound_manager.cpp
+++ b/src/ad_sound_manager.cpp
@@ -81,9 +81,10 @@ AdSoundManager::AdSoundManager(const rclcpp::NodeOptions & options = rclcpp::Nod
   // ============================================================
 
   // For: /system/emergency/hazard_status (emergency_holding)
+  // Note: Use QoS{1} (volatile) to match publisher QoS
   sub_hazard_status_ = this->create_subscription<autoware_system_msgs::msg::HazardStatusStamped>(
     "/system/emergency/hazard_status",
-    rclcpp::QoS{1}.transient_local(),
+    rclcpp::QoS{1},
     std::bind(&AdSoundManager::callbackHazardStatus, this, std::placeholders::_1)
   );
 

--- a/test/test_ad_sound_manager.cpp
+++ b/test/test_ad_sound_manager.cpp
@@ -20,6 +20,7 @@
 #include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/vehicle_status.hpp>
+#include <autoware_adapi_v1_msgs/msg/turn_indicators.hpp>
 #include <autoware_state_machine_msgs/msg/state_machine.hpp>
 #include <autoware_system_msgs/msg/hazard_status_stamped.hpp>
 #include <audio_driver_msgs/msg/sound_driver_res.hpp>
@@ -29,6 +30,7 @@ using RouteState = autoware_adapi_v1_msgs::msg::RouteState;
 using LocalizationState = autoware_adapi_v1_msgs::msg::LocalizationInitializationState;
 using OperationModeState = autoware_adapi_v1_msgs::msg::OperationModeState;
 using VehicleStatus = autoware_adapi_v1_msgs::msg::VehicleStatus;
+using TurnIndicators = autoware_adapi_v1_msgs::msg::TurnIndicators;
 using StateMachine = autoware_state_machine_msgs::msg::StateMachine;
 using HazardStatusStamped = autoware_system_msgs::msg::HazardStatusStamped;
 using SoundDriverRes = audio_driver_msgs::msg::SoundDriverRes;
@@ -167,6 +169,8 @@ protected:
       "/api/localization/initialization_state", rclcpp::QoS{1}.transient_local());
     operation_mode_pub_ = test_node_->create_publisher<OperationModeState>(
       "/api/operation_mode/state", rclcpp::QoS{1}.transient_local());
+    vehicle_status_pub_ = test_node_->create_publisher<VehicleStatus>(
+      "/api/vehicle/status", rclcpp::SensorDataQoS());
     sound_res_pub_ = test_node_->create_publisher<SoundDriverRes>(
       "/sound_voice_alarm/audio_res", rclcpp::QoS{3}.transient_local());
     hazard_status_pub_ = test_node_->create_publisher<HazardStatusStamped>(
@@ -242,6 +246,14 @@ protected:
     spinOnce(3);
   }
 
+  void publishVehicleStatus(uint8_t turn_indicators)
+  {
+    auto msg = VehicleStatus();
+    msg.turn_indicators.status = turn_indicators;
+    vehicle_status_pub_->publish(msg);
+    spinOnce(3);
+  }
+
   std::shared_ptr<TestableAdSoundManager> node_;
   std::shared_ptr<rclcpp::Node> test_node_;
 
@@ -249,6 +261,7 @@ protected:
   rclcpp::Publisher<RouteState>::SharedPtr route_pub_;
   rclcpp::Publisher<LocalizationState>::SharedPtr localization_pub_;
   rclcpp::Publisher<OperationModeState>::SharedPtr operation_mode_pub_;
+  rclcpp::Publisher<VehicleStatus>::SharedPtr vehicle_status_pub_;
   rclcpp::Publisher<SoundDriverRes>::SharedPtr sound_res_pub_;
   rclcpp::Publisher<HazardStatusStamped>::SharedPtr hazard_status_pub_;
 };
@@ -528,6 +541,71 @@ TEST_F(StateTransitionTest, HasStartedDrivingFlag_ResetWhenRouteUnset)
   publishRoute(RouteState::UNSET);
 
   EXPECT_FALSE(node_->hasStartedDriving());
+}
+
+// ============================================================
+// Turn Indicator Tests (Right/Left Turn Sound)
+// ============================================================
+
+// Test: When turn_indicators=RIGHT during MOVING, transition to STATE_TURNING_RIGHT
+TEST_F(StateTransitionTest, TurnIndicatorsRight_TransitionToTurningRight)
+{
+  // Complete startup to RUNNING
+  spinOnce(5);
+  publishSoundResponse();
+  publishLocalization(LocalizationState::INITIALIZED);
+  publishRoute(RouteState::SET);
+  publishMotion(MotionState::STOPPED);
+  publishMotion(MotionState::STARTING);
+  publishSoundResponse();
+  publishMotion(MotionState::MOVING);
+  EXPECT_EQ(node_->getServiceLayerState(), StateMachine::STATE_RUNNING);
+
+  // Right turn indicator
+  publishVehicleStatus(TurnIndicators::RIGHT);
+
+  EXPECT_EQ(node_->getServiceLayerState(), StateMachine::STATE_TURNING_RIGHT);
+}
+
+// Test: When turn_indicators=LEFT during MOVING, transition to STATE_TURNING_LEFT
+TEST_F(StateTransitionTest, TurnIndicatorsLeft_TransitionToTurningLeft)
+{
+  // Complete startup to RUNNING
+  spinOnce(5);
+  publishSoundResponse();
+  publishLocalization(LocalizationState::INITIALIZED);
+  publishRoute(RouteState::SET);
+  publishMotion(MotionState::STOPPED);
+  publishMotion(MotionState::STARTING);
+  publishSoundResponse();
+  publishMotion(MotionState::MOVING);
+  EXPECT_EQ(node_->getServiceLayerState(), StateMachine::STATE_RUNNING);
+
+  // Left turn indicator
+  publishVehicleStatus(TurnIndicators::LEFT);
+
+  EXPECT_EQ(node_->getServiceLayerState(), StateMachine::STATE_TURNING_LEFT);
+}
+
+// Test: When turn_indicators changes from RIGHT to DISABLE, transition back to STATE_RUNNING
+TEST_F(StateTransitionTest, TurnIndicatorsDisable_TransitionBackToRunning)
+{
+  // Complete startup to RUNNING, then turn right
+  spinOnce(5);
+  publishSoundResponse();
+  publishLocalization(LocalizationState::INITIALIZED);
+  publishRoute(RouteState::SET);
+  publishMotion(MotionState::STOPPED);
+  publishMotion(MotionState::STARTING);
+  publishSoundResponse();
+  publishMotion(MotionState::MOVING);
+  publishVehicleStatus(TurnIndicators::RIGHT);
+  EXPECT_EQ(node_->getServiceLayerState(), StateMachine::STATE_TURNING_RIGHT);
+
+  // Turn indicator off
+  publishVehicleStatus(TurnIndicators::DISABLE);
+
+  EXPECT_EQ(node_->getServiceLayerState(), StateMachine::STATE_RUNNING);
 }
 
 // ============================================================

--- a/test/test_ad_sound_manager.cpp
+++ b/test/test_ad_sound_manager.cpp
@@ -174,7 +174,7 @@ protected:
     sound_res_pub_ = test_node_->create_publisher<SoundDriverRes>(
       "/sound_voice_alarm/audio_res", rclcpp::QoS{3}.transient_local());
     hazard_status_pub_ = test_node_->create_publisher<HazardStatusStamped>(
-      "/system/emergency/hazard_status", rclcpp::QoS{1}.transient_local());
+      "/system/emergency/hazard_status", rclcpp::QoS{1});
 
     // Wait for connections to establish
     std::this_thread::sleep_for(std::chrono::milliseconds(200));


### PR DESCRIPTION
## Description

ad_sound_managerのQoS設定を修正し、右左折音声と緊急停止音声が正しく再生されるようにしました。

### 変更内容

1. **`/api/vehicle/status` のQoS修正** (0b7b405)
   - `QoS{1}.transient_local()` → `SensorDataQoS()` に変更
   - Publisher側が `BEST_EFFORT + volatile` を使用しているため、Subscriber側も合わせて修正
   - これにより `turn_indicators` を正しく受信でき、右左折音声（`STATE_TURNING_LEFT/RIGHT`）が再生されるようになった

2. **`/system/emergency/hazard_status` のQoS修正** (821386f)
   - `QoS{1}.transient_local()` → `QoS{1}` (volatile) に変更
   - Publisher側が `volatile` を使用しているため、DURABILITY_QOS_POLICY の不一致を解消
   - これにより `emergency_holding` を正しく受信でき、`STATE_EMERGENCY_STOP` への遷移が可能になった

3. **詳細な状態遷移ログの追加** (0b7b405)
   - デバッグ用に全トピック情報を時系列で出力するログを追加

4. **右左折テストケースの追加** (0b7b405)
   - `TurnIndicatorsRight_TransitionToTurningRight`
   - `TurnIndicatorsLeft_TransitionToTurningLeft`
   - `TurnIndicatorsDisable_TransitionBackToRunning`

## How was this PR tested?

1. **ユニットテスト**
   - `colcon test --packages-select ad_sound_manager` で全20テストが通過
   - 新規追加した右左折テスト3件も通過

2. **シミュレーションテスト**
   - PSIMで実車シナリオを実行し、以下を確認：
     - 右折時に `STATE_TURNING_RIGHT` に遷移し、`right.wav` が再生される
     - 左折時に `STATE_TURNING_LEFT` に遷移し、`left.wav` が再生される
     - 緊急停止時に `STATE_EMERGENCY_STOP` に遷移する
     - QoS不一致の警告が出力されないこと

## Notes for reviewers

- QoS設定の変更により、既存の動作に影響はありません（メッセージを受信できていなかったものが受信できるようになっただけ）
- デバッグログは `RCLCPP_WARN` レベルで出力されます。本番環境ではログレベルを調整することで非表示にできます

## Effects on system behavior

| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| 右左折音声 | 再生されない（QoS不一致でturn_indicatorsを受信できず） | 正常に再生される |
| 緊急停止音声 | STATE_EMERGENCY_STOPに遷移しない | 正常に遷移する |
| ログ出力 | 簡易的なログのみ | 詳細な状態遷移ログを追加 |