### PR TITLE
refactor: update hazard status message dependencies and subscriptions

### DIFF
--- a/include/ad_sound_manager/ad_sound_manager.hpp
+++ b/include/ad_sound_manager/ad_sound_manager.hpp
@@ -46,9 +46,9 @@
 // For: external system integration (voice_flg, lock_flg)
 #include "go_interface_msgs/msg/vehicle_status.hpp"
 
-// System messages
-// For: /system/emergency/hazard_status (emergency_holding)
-#include "autoware_system_msgs/msg/hazard_status_stamped.hpp"
+// External API messages
+// For: /api/external/get/hazard_status (emergency_holding)
+#include "tier4_external_api_msgs/msg/hazard_status_stamped.hpp"
 
 // Legacy messages (to be removed after migration)
 // For: /awapi/vehicle/get/status (legacy - to be replaced by /api/vehicle/status)
@@ -142,7 +142,7 @@ protected:
   go_interface_msgs::msg::VehicleStatus go_interface_vehicle_status_;
   go_interface_msgs::msg::VehicleStatus prev_go_interface_vehicle_status_;
 
-  // For: /system/emergency/hazard_status (emergency_holding)
+  // For: /api/external/get/hazard_status (emergency_holding)
   bool emergency_holding_ = false;
 
   // Sound playback state for localization initial pose
@@ -198,8 +198,8 @@ private:
   // ============================================================
   // Subscriptions - System
   // ============================================================
-  // For: /system/emergency/hazard_status (emergency_holding)
-  rclcpp::Subscription<autoware_system_msgs::msg::HazardStatusStamped>::SharedPtr sub_hazard_status_;
+  // For: /api/external/get/hazard_status (emergency_holding)
+  rclcpp::Subscription<tier4_external_api_msgs::msg::HazardStatusStamped>::SharedPtr sub_hazard_status_;
 
   // ============================================================
   // Subscriptions - Legacy (TODO: Replace with planning_factors)
@@ -268,9 +268,9 @@ private:
   // ============================================================
   // Callback functions - System
   // ============================================================
-  // For: /system/emergency/hazard_status (emergency_holding)
+  // For: /api/external/get/hazard_status (emergency_holding)
   void callbackHazardStatus(
-    const autoware_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg);
+    const tier4_external_api_msgs::msg::HazardStatusStamped::ConstSharedPtr msg);
 
   // ============================================================
   // Callback functions - Legacy (TODO: Replace with planning_factors)

--- a/package.xml
+++ b/package.xml
@@ -32,9 +32,6 @@
   <!-- New ADAPI v1 messages -->
   <depend>autoware_adapi_v1_msgs</depend>
 
-  <!-- System messages -->
-  <depend>autoware_system_msgs</depend>
-
   <!-- go_interface messages (external system integration) -->
   <depend>go_interface_msgs</depend>
 

--- a/src/ad_sound_manager.cpp
+++ b/src/ad_sound_manager.cpp
@@ -80,10 +80,10 @@ AdSoundManager::AdSoundManager(const rclcpp::NodeOptions & options = rclcpp::Nod
   // Subscriptions - System
   // ============================================================
 
-  // For: /system/emergency/hazard_status (emergency_holding)
+  // For: /api/external/get/hazard_status (emergency_holding)
   // Note: Use QoS{1} (volatile) to match publisher QoS
-  sub_hazard_status_ = this->create_subscription<autoware_system_msgs::msg::HazardStatusStamped>(
-    "/system/emergency/hazard_status",
+  sub_hazard_status_ = this->create_subscription<tier4_external_api_msgs::msg::HazardStatusStamped>(
+    "/api/external/get/hazard_status",
     rclcpp::QoS{1},
     std::bind(&AdSoundManager::callbackHazardStatus, this, std::placeholders::_1)
   );
@@ -872,7 +872,7 @@ void AdSoundManager::callbackGoInterfaceVehicleStatus(
 // ============================================================
 
 void AdSoundManager::callbackHazardStatus(
-  const autoware_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg)
+  const tier4_external_api_msgs::msg::HazardStatusStamped::ConstSharedPtr msg)
 {
   bool prev_emergency_holding = emergency_holding_;
   emergency_holding_ = msg->status.emergency_holding;

--- a/test/test_ad_sound_manager.cpp
+++ b/test/test_ad_sound_manager.cpp
@@ -22,7 +22,7 @@
 #include <autoware_adapi_v1_msgs/msg/vehicle_status.hpp>
 #include <autoware_adapi_v1_msgs/msg/turn_indicators.hpp>
 #include <autoware_state_machine_msgs/msg/state_machine.hpp>
-#include <autoware_system_msgs/msg/hazard_status_stamped.hpp>
+#include <tier4_external_api_msgs/msg/hazard_status_stamped.hpp>
 #include <audio_driver_msgs/msg/sound_driver_res.hpp>
 
 using MotionState = autoware_adapi_v1_msgs::msg::MotionState;
@@ -32,7 +32,7 @@ using OperationModeState = autoware_adapi_v1_msgs::msg::OperationModeState;
 using VehicleStatus = autoware_adapi_v1_msgs::msg::VehicleStatus;
 using TurnIndicators = autoware_adapi_v1_msgs::msg::TurnIndicators;
 using StateMachine = autoware_state_machine_msgs::msg::StateMachine;
-using HazardStatusStamped = autoware_system_msgs::msg::HazardStatusStamped;
+using HazardStatusStamped = tier4_external_api_msgs::msg::HazardStatusStamped;
 using SoundDriverRes = audio_driver_msgs::msg::SoundDriverRes;
 
 // ============================================================
@@ -174,7 +174,7 @@ protected:
     sound_res_pub_ = test_node_->create_publisher<SoundDriverRes>(
       "/sound_voice_alarm/audio_res", rclcpp::QoS{3}.transient_local());
     hazard_status_pub_ = test_node_->create_publisher<HazardStatusStamped>(
-      "/system/emergency/hazard_status", rclcpp::QoS{1});
+      "/api/external/get/hazard_status", rclcpp::QoS{1});
 
     // Wait for connections to establish
     std::this_thread::sleep_for(std::chrono::milliseconds(200));


### PR DESCRIPTION
# description
Migrate the `emergency_holding` topic from `/system/emergency/hazard_status` to `/api/external/get/hazard_status`.

# test

1. add  `export AD_SOUND_LANGUAGE=ja`
2. Psim launcher and rviz plugin set emergency 30seconds,when `/api/external/get/hazard_status`'s emergency_holding field is true,
3.  when `/api/external/get/hazard_status`'s emergency_holding field is true, I checked BGM sound is stopped.